### PR TITLE
Add pyodbc and SQLAlchemy dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 flask
 pandas
+pyodbc
+sqlalchemy


### PR DESCRIPTION
## Summary
- Ensure the environment includes `pyodbc` and `SQLAlchemy`
- Declare `pyodbc` and `SQLAlchemy` in `requirements.txt`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fdeb5ae108331ba79b0db44584e48